### PR TITLE
Fixed Warnings when directly accessed - RCTNodeCamera and RCTNodePlay…

### DIFF
--- a/NodeCameraModule.js
+++ b/NodeCameraModule.js
@@ -27,7 +27,7 @@ class NodeCameraView extends Component {
   switchCamera() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.switchCamera,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.switchCamera,
       null
     );
   }
@@ -35,7 +35,7 @@ class NodeCameraView extends Component {
   flashEnable(enable) {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.flashEnable,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.flashEnable,
       [enable]
     );
   }
@@ -43,7 +43,7 @@ class NodeCameraView extends Component {
   startPreview() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.startprev,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.startprev,
       null
     );
   }
@@ -51,7 +51,7 @@ class NodeCameraView extends Component {
   stopPreview() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.stopprev,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.stopprev,
       null
     );
   }
@@ -59,7 +59,7 @@ class NodeCameraView extends Component {
   start() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.start,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.start,
       null
     );
   }
@@ -67,7 +67,7 @@ class NodeCameraView extends Component {
   stop() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodeCamera.Commands.stop,
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.stop,
       null
     );
   }

--- a/NodePlayerModule.js
+++ b/NodePlayerModule.js
@@ -27,7 +27,7 @@ class NodePlayerView extends Component {
   pause() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodePlayer.Commands.pause,
+      UIManager.getViewManagerConfig('RCTNodePlayer').Commands.pause,
       null
     );
   }
@@ -35,7 +35,7 @@ class NodePlayerView extends Component {
   start() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodePlayer.Commands.start,
+      UIManager.getViewManagerConfig('RCTNodePlayer').Commands.start,
       null
     );
   }
@@ -43,7 +43,7 @@ class NodePlayerView extends Component {
   stop() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this.refs[RCT_VIDEO_REF]),
-      UIManager.RCTNodePlayer.Commands.stop,
+      UIManager.getViewManagerConfig('RCTNodePlayer').Commands.stop,
       null
     );
   }


### PR DESCRIPTION
Fixed Below Warnings:

Accessing view manager configs directly off UIManager via UIManager['RCTNodeCamera'] is no longer supported. Use UIManager.getViewManagerConfig('RCTNodeCamera') instead.
- node_modules/expo/build/environment/muteWarnings.fx.js:18:23 in warn
- node_modules/react-native/Libraries/ReactNative/UIManager.js:164:12 in get
- node_modules/react-native/Libraries/Utilities/defineLazyObjectProperty.js:42:18 in getValue
- node_modules/react-native-nodemediaclient/NodeCameraModule.js:62:16 in start
* src/screens/live-stream/LiveStreamScreen.js:30:4 in componentDidMount
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:15036:10 in commitLifeCycles
- node_modules/react-native/Libraries/Renderer/oss/ReactNativeRenderer-dev.js:16636:8 in commitAllLifeCycles
- ... 18 more stack frames from framework internals