### PR TITLE
Fix import androidx.test.InstrumentationRegistry; does not exist when…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,11 +5,12 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-
+        testBuildType System.getProperty('testBuildType', 'debug')
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -23,7 +24,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.github.NodeMedia:NodeMediaClient-Android:2.8.1'
+    implementation 'com.github.NodeMedia:NodeMediaClient-Android:2.7.2'
     implementation 'com.android.support:appcompat-v7:28.0.1'
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    androidTestImplementation('com.wix:detox:+') { transitive = true }
+    androidTestImplementation 'junit:junit:4.12'
+    implementation "androidx.annotation:annotation:1.1.0"
 }


### PR DESCRIPTION
… yarn detox build
When implementation e2e test use detox and yarn detox build command 