### PR TITLE
feat(ios): suppport capturing pictures when streaming

### DIFF
--- a/NodeCameraModule.js
+++ b/NodeCameraModule.js
@@ -23,6 +23,13 @@ class NodeCameraView extends Component {
     }
     this.props.onStatus(event.nativeEvent.code, event.nativeEvent.msg);
   }
+  _onCapturePicture(event) {
+    if (!this.props.onCapturePicture) {
+      return;
+    }
+
+    this.props.onCapturePicture(event.nativeEvent.picture);
+  }
 
   switchCamera() {
     UIManager.dispatchViewManagerCommand(
@@ -72,11 +79,21 @@ class NodeCameraView extends Component {
     );
   }
 
+  capturePicture() {
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this.refs[RCT_VIDEO_REF]),
+      UIManager.getViewManagerConfig('RCTNodeCamera').Commands.capturePicture,
+      null
+    );
+  }
+
+
   render() {
     return <RCTNodeCamera
       {...this.props}
       ref={RCT_VIDEO_REF}
       onChange={this._onChange.bind(this)}
+      onCapturePicture={this._onCapturePicture.bind(this)}
     />;
   };
 }
@@ -106,11 +123,12 @@ NodeCameraView.propTypes = {
   smoothSkinLevel: PropTypes.oneOf([0, 1, 2, 3, 4, 5]),
   cryptoKey:PropTypes.string,
   onStatus: PropTypes.func,
+  onCapturePicture: PropTypes.func,
   ...View.propTypes // 包含默认的View的属性
 };
 
 const RCTNodeCamera = requireNativeComponent('RCTNodeCamera', NodeCameraView, {
-  nativeOnly: { onChange: true }
+  nativeOnly: { onChange: true, onCapturePicture: true }
 });
 
 module.exports = NodeCameraView;

--- a/ios/RCTNodeMediaClient/RCTNodeCameraManager.m
+++ b/ios/RCTNodeMediaClient/RCTNodeCameraManager.m
@@ -31,11 +31,12 @@ RCT_EXPORT_VIEW_PROPERTY(dynamicRateEnable, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(smoothSkinLevel, int);
 RCT_EXPORT_VIEW_PROPERTY(cryptoKey, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onCapturePicture, RCTBubblingEventBlock)
 
 
 RCT_EXPORT_METHOD(startprev:(nonnull NSNumber *)reactTag)
 {
-  
+
   [self.bridge.uiManager addUIBlock:
    ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTNodeCameraView *> *viewRegistry){
      RCTNodeCameraView *view = viewRegistry[reactTag];
@@ -91,6 +92,16 @@ RCT_EXPORT_METHOD(flashEnable:(nonnull NSNumber *)reactTag enable:(BOOL)enable)
    ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTNodeCameraView *> *viewRegistry){
      RCTNodeCameraView *view = viewRegistry[reactTag];
      [view setFlashEnable:enable];
+   }];
+}
+
+RCT_EXPORT_METHOD(capturePicture:(nonnull NSNumber *)reactTag)
+{
+
+  [self.bridge.uiManager addUIBlock:
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTNodeCameraView *> *viewRegistry){
+     RCTNodeCameraView *view = viewRegistry[reactTag];
+    [view capturePicture];
    }];
 }
 

--- a/ios/RCTNodeMediaClient/RCTNodeCameraView.h
+++ b/ios/RCTNodeMediaClient/RCTNodeCameraView.h
@@ -21,6 +21,7 @@
 @property (nonatomic) NSInteger smoothSkinLevel;
 @property (strong, nonatomic) NSString *cryptoKey;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onCapturePicture;
 
 @property (nonatomic) BOOL flashEnable;
 
@@ -29,6 +30,6 @@
 -(int)start;
 -(int)stop;
 -(int)switchCamera;
-
+-(void)capturePicture;
 
 @end

--- a/ios/RCTNodeMediaClient/RCTNodeCameraView.m
+++ b/ios/RCTNodeMediaClient/RCTNodeCameraView.m
@@ -30,6 +30,7 @@
     _audio = nil;
     _video = nil;
     _onChange = nil;
+    _onCapturePicture = nil;
   }
   return self;
 }
@@ -124,5 +125,15 @@
 -(int)switchCamera {
   return [_np switchCamera];
 }
+
+-(void)capturePicture {
+  return [_np capturePicture:^(UIImage * _Nullable picture) {
+    NSData *pictureData = UIImagePNGRepresentation(picture);
+    NSString *pictureBase64 = [pictureData base64EncodedStringWithOptions:0];
+    self.onCapturePicture(@{@"picture":pictureBase64});
+  }];
+}
+
+
 
 @end


### PR DESCRIPTION
Hey guys,

I saw a couple of issues raised about this, and though I don't urgently need it in my project I thought I'd go ahead and implement it. Unfortunately, I don't need to Android support in my project, so this PR is iOS-only.

Sample usage:
```js
import CameraRoll from '@react-native-community/cameraroll';
import { NodeCameraView } from 'react-native-nodemediaclient';

const CameraView = () => {
  return (
    <StyledNodeCameraView
      // ...
      onCapturePicture={(picture) => {
        CameraRoll.save(`data:image/png;base64,${picture}`, { type: 'photo' });
      }}
    />
  );
};
```

Resolves #93.